### PR TITLE
CURRIKI-6045 : Enable JsSkinFileExtensionPlugin entry point

### DIFF
--- a/web/src/main/webapp/skins/curriki8/javascripts.vm
+++ b/web/src/main/webapp/skins/curriki8/javascripts.vm
@@ -116,7 +116,7 @@ Curriki.global.isAdmin = #if($hasGlobalAdmin)true#{else}false#{end};
 #if($globalDebug)##{
     <script type="text/javascript">if(Curriki.console) { Curriki.console.log("Now in "+window.name+" on: " + window.location.href ); Curriki.console.log(" inside frame? " + (window.top!=window)); } </script>
 #end##}
-## (Disabled) hook for inserting JavaScript skin extensions
+<!-- com.xpn.xwiki.plugin.skinx.JsSkinFileExtensionPlugin -->
 ## Use $xwiki.jsfx.use("jsfile.js", true)
 <!-- com.xpn.xwiki.plugin.skinx.JsSkinExtensionPlugin -->
 ## the HTML comment there actually inserts it!


### PR DESCRIPTION
Enable jsfx plugin entry point in curriki8 skin. This is required by various macros from macros.vm, especially the wysiwyg editor helper macros.
